### PR TITLE
Update get_imap_email.py

### DIFF
--- a/bin/get_imap_email.py
+++ b/bin/get_imap_email.py
@@ -617,9 +617,9 @@ class IMAPProcessor(object):
 				if not self.fullHeaders:
 					lk = string.lower(k)
 					if lk == 'from' or lk == 'to' or lk == 'subject' or lk == 'date' or lk == 'cc':
-						cstr.write(k +	' = "' + string.replace(v,'"','') + '"\n')
+						cstr.write(k +	' = "' + string.replace(v,'"','').replace('\n', '').replace('\r', '') + '"\n')
 				else:
-					cstr.write(k +	' = "' + string.replace(v,'"','') + '"\n')
+					cstr.write(k +	' = "' + string.replace(v,'"','').replace('\n', '').replace('\r', '') + '"\n')
 	
 			# include size and name of folder since they are not part of header
 			# interestingly, sometimes these come back quoted - so check.


### PR DESCRIPTION
Making header info "stay" in one line. This is done by removing any new line and carriage returns that the mail header might have for the following fields: to, from, subject, date, cc. This will also remove said characters from full header extractions.