### PR TITLE
Splunk 8 / Python 3 support (incomplete)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.4
+current_version = 2.0.5-beta1
 tag = True
 commit = True
 
@@ -14,9 +14,9 @@ replace = self.version = "{new_version}"
 [bumpversion:part:release]
 optional_value = beta
 first_value = beta
-values =
-    beta
-    rc
+values = 
+	beta
+	rc
 
 [bumpversion:part:build]
 first_value = 1

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,22 @@
+[bumpversion]
+current_version = 2.0.4
+tag = True
+commit = True
+
+[bumpversion:file:default/app.conf]
+search = version = {current_version}
+replace = version = {new_version}
+
+[bumpversion:file:bin/get_imap_email.py]
+search = self.version = "{current_version}"
+replace = self.version = "{new_version}"
+
+[bumpversion:part:release]
+optional_value = beta
+first_value = beta
+values =
+    beta
+    rc
+
+[bumpversion:part:build]
+first_value = 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# General excludes
+*.bak
+*.tmp
+.*.swp
+*.log
+*~
+*.DS_Store
+
+
+# Build artifacts
+build/
+dist/
+lib/
+.latest_release
+
+
+# IDE / Editors
+.idea
+.vscode/
+
+
+# Python / dev
+__pycache__/
+*.py[cod]
+*$py.class
+.Python
+.venv
+venv
+.python-version
+pip-log.txt
+*.dist-info/
+*.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ venv
 pip-log.txt
 *.dist-info/
 *.egg-info/
+.release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+---
+
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.5.0
+  hooks:
+    - id: trailing-whitespace
+      exclude: (README\.md|\.bumpversion.cfg)$
+    - id: end-of-file-fixer
+      exclude: (README\.md|\.bumpversion.cfg)$
+    - id: check-json
+    - id: check-xml
+    - id: check-ast
+    - id: check-added-large-files
+      args: [ '--maxkb=50' ]
+    - id: check-merge-conflict
+    - id: mixed-line-ending
+      args: [ '--fix=lf' ]
+
+- repo: https://github.com/Kintyre/ksconf
+  rev: v0.7.8
+  hooks:
+    - id: ksconf-check
+    - id: ksconf-sort
+      exclude: logging\.conf
+    - id: ksconf-xml-format

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ In my case I forward all unix root system messages to one mailbox that I index f
 
 I've signed up for mailing lists to my indexed email address and create reports and alerts based on only certain content I'm interested in looking for.
 
+# What's new in 2.0.5!
+
+- Initial Splunk 8 and Python 3 support.  (Lowell Alleman, Kintyre)
+- Force single line for header fields (Pedro J Toro)
+- Fixed quoting issues with external calls to `openssl` (Ivan Dvoenosov)
+- Tons of fixups, formatting, and best practices. (Lowell Alleman, Kintyre)
 
 # What's new in 2.0.4!
 

--- a/bin/genpass.sh
+++ b/bin/genpass.sh
@@ -22,7 +22,7 @@ if [ $pass = $pass2 ]; then
 
     echo ""
     echo ""
-    echo -n $pass | openssl bf -e -a -pass file:$SPLUNK_HOME/etc/auth/splunk.secret
+    echo -n $pass | openssl bf -e -a -pass file:"$SPLUNK_HOME/etc/auth/splunk.secret"
     
     echo ""
     echo "Copy the string on the line above and paste it into"

--- a/bin/get_imap_email.py
+++ b/bin/get_imap_email.py
@@ -31,7 +31,7 @@ __doc__ = """
 #
 """
 
-import getopt, sys, imaplib, os, string, email, logging, time
+import getopt, sys, imaplib, os, email, logging, time
 import subprocess, traceback, datetime, io, base64, quopri
 
 try:
@@ -356,7 +356,7 @@ class IMAPProcessor(object):
 			  result,list = M.list();
 			  for f in list[:]:
 				  x = f.split()
-				  mailbox = string.join(x[2:])
+				  mailbox = " ".join(x[2:])
 				  folder_list.append(mailbox)
 		  
 		  # If the user supplied a list of mailboxes, split them up and put in list
@@ -619,11 +619,11 @@ class IMAPProcessor(object):
 				if k == 'date' or k == 'Date':
 				  continue
 				if not self.fullHeaders:
-					lk = string.lower(k)
+					lk = k.lower()
 					if lk == 'from' or lk == 'to' or lk == 'subject' or lk == 'date' or lk == 'cc':
-						cstr.write(k +	' = "' + string.replace(v,'"','').replace('\n', '').replace('\r', '') + '"\n')
+						cstr.write(k + ' = "' + v.replace('"', '').replace('\n', '').replace('\r', '') + '"\n')
 				else:
-					cstr.write(k +	' = "' + string.replace(v,'"','').replace('\n', '').replace('\r', '') + '"\n')
+					cstr.write(k + ' = "' + v.replace('"', '').replace('\n', '').replace('\r', '') + '"\n')
 	
 			# include size and name of folder since they are not part of header
 			# interestingly, sometimes these come back quoted - so check.

--- a/bin/get_imap_email.py
+++ b/bin/get_imap_email.py
@@ -7,19 +7,19 @@ __doc__ = """
 #
 # Change History
 # --------------
-# Date		   Author		 Changes
-# -----		   ------		 ---------
-# 07/10/2008	   Jimmy J	 Changes to do the caching by reading the latest UID from splunk messages itself
-#				 Code modified to write a UID key/value pair for every message
-#				 Removed all commented code
-#				 Fixed the function 'usage'
-#				 Removed the hard-coded path separator '/', instead used 
+# Date             Author                Changes
+# -----            ------                ---------
+# 07/10/2008       Jimmy J       Changes to do the caching by reading the latest UID from splunk messages itself
+#                                Code modified to write a UID key/value pair for every message
+#                                Removed all commented code
+#                                Fixed the function 'usage'
+#                                Removed the hard-coded path separator '/', instead used
 #                                  os.path.join so it will work even if run on a non *nix platform
-#				 Imported traceback module for improved error reporting
-#				 Got rid of the splunk CLI interface to determine the last UID 
+#                                Imported traceback module for improved error reporting
+#                                Got rid of the splunk CLI interface to determine the last UID
 #                                  and used the splunk REST API instead
-#				 Got rid of imports that were not being used 
-#				 Made the splunkHost, splunkuser, splunkpassword and splunkxpassword configurable
+#                                Got rid of imports that were not being used
+#                                Made the splunkHost, splunkuser, splunkpassword and splunkxpassword configurable
 #
 # 02/11/2014    PJ Balsley       Updated script.
 #                                Fixed reading some imap.conf settings that only worked with False/True, and not with 0/1.
@@ -42,25 +42,25 @@ except ImportError:
 
 # Generic error class
 class ConfigError(Exception):
-   pass
+    pass
 
 class LoginError(Exception):
-	pass
+    pass
 
 splunk_home = os.getenv('SPLUNK_HOME')
 if not splunk_home:
-	raise ConfigError('Environment variable SPLUNK_HOME must be set. Run: source ~/bin/setSplunkEnv')
+    raise ConfigError('Environment variable SPLUNK_HOME must be set. Run: source ~/bin/setSplunkEnv')
 
 #
-# This is the list of configuration options that can be set either on the 
-# command line or via the imap.conf file.  Note that these names must 
-# correspond exactly to field names in the IMAPProcessor class and the names 
+# This is the list of configuration options that can be set either on the
+# command line or via the imap.conf file.  Note that these names must
+# correspond exactly to field names in the IMAPProcessor class and the names
 # specified in the optlist near the bottom of this file.
 #
-# The imap.conf configuration file provides more detailed documentation about 
+# The imap.conf configuration file provides more detailed documentation about
 # the effects of each of the options.
 #
-configOptions = [ 
+configOptions = [
   "server",               # imap server name/ip
   "user",                 # imap user account
   "password",             # imap plaintext password
@@ -73,7 +73,7 @@ configOptions = [
   "mimeTypes",            # list of mime types to index if multipart
   "splunkuser",           # splunk server userid
   "splunkpassword",       # splunk server password
-  "splunkxpassword",      # or splunk server encrypted password 
+  "splunkxpassword",      # or splunk server encrypted password
   "splunkHostPath",       # splunk server host path
   "timeout",              # seconds to wait for connected to mailserver.
   "noCache",              # if true, the 'already indexed' markers are ignored
@@ -97,625 +97,625 @@ configSectionName = "IMAP Configuration"
 #--------------------------------------------------------------
 class IMAPProcessor(object):
 
-	# -------------------
-        # default values.
-	# -------------------
-	def __init__(self):
-		# initialize all of the configuration fields with default values that
-		# will be used on the off chance that they don't appear in imap.conf
-		self.server = ""	# this is required
-		self.user = ""		# this is required
-		self.password = ""	# and either this...
-		self.xpassword = ""     # ...or this is also required
-                self.port = 993
-                self.folders = 'all'
-                self.imapSearch = 'UNDELETED'
-                self.fullHeaders = False
-                self.includeBody = True
-                self.mimeTypes = 'text/plain'
-                self._mimeTypesList = []             # split list of mime types
-                self.splunkuser = 'admin'
-                self.splunkpassword = 'changeme'     # default splunk admin password
-                self.splunkxpassword = ''
-                self.splunkHostPath = 'https://localhost:8089'
-                self.timeout = 10
-                self.noCache = False
-                self.debug = False
-                self.useSSL = True
-                self.deleteWhenDone = False
-                self.END_IMAP_BREAKER = 'EndIMAPMessage'
-                self.bodySourceType = 'imapbody'
-                self.body_separator = '____________________  Message Body  ____________________'
-                self.headerSourceType = 'imap'
-                self.useBodySourceType = False
-                self.version = "2.0"
-
-
-	# -----------------------------------
-        # read in all options and settings.
-	# -----------------------------------
-	def initFromOptlist(self, optlist):
-		# First read settings in imap.conf, if it exists...
-		self.readConfig()
-
-		# ...now, for debugging and backward compat, allow command line 
-		# settings to override...
-		self.readOptlist(optlist)
- 
-		if self.debug:
-		  logging.basicConfig(level=logging.DEBUG)
-		  keys = sorted(self.__dict__.keys())
-		  for k in keys:
-			if k.startswith("_"): continue
-			logging.debug(k + "=" + str(self.__dict__[k]))
-		else:
-			logging.basicConfig(level=logging.ERROR)
-
-		# check min required args
-		if self.server == "" or self.user == "" or ( self.password == "" and self.xpassword =="" ):
-			self.usage()
-			#sys.exit()
-			raise ConfigError
-
-		# pre-parse the mime types list
-		if self.mimeTypes.find(",") > -1:
-		  self._mimeTypesList = self.mimeTypes.split(",")
-		else:
-		  self._mimeTypesList.append(self.mimeTypes)
-
-		# deleteWhenDone overrides any caching. Our assumption is that all messages in the box are new each time
-		if self.deleteWhenDone:
-		  self.noCache = True
-
-	# -----------------------------------
-        # - Read settings from imap.conf(s) 
-	# -----------------------------------
-	def readConfig(self):
-	  path = ''
-	  if os.path.exists(configLocalFileName):
-		path = configLocalFileName
-	  elif os.path.exists(configDefaultFileName):
-		path = configDefaultFileName
-	  else:
-		return
-	  config = RawConfigParser()
-	  config.read(path)
-	  for o in configOptions:
-		if config.has_option(configSectionName, o):
-		  val = getattr(self, o)
-		  # check to see if the current/default value is a boolean; if so,
-		  # makes user user supplied value is a bool, will convert string to bool.
-                  # ie. makes 0 = False and 1 = True
-		  if val.__class__ == bool:
-			val = (config.get(configSectionName, o).strip().lower() == "true")
-                        if config.get(configSectionName, o) == "1":
-                           val = True
-                        if config.get(configSectionName, o) == "0":
-                           val = False
-		  else: 
-			val = config.get(configSectionName, o)
-		  setattr(self, o, val)
-
-
-	# ----------------------------------------------------------------
-        # Read settings from the command line.  We support command
-        # line args mainly for backwards compat and for quick debugging;
-        # users should be encouraged to use the imap.conf file instead
-	# ----------------------------------------------------------------
-	def readOptlist(self, optlist):
-	  for o, a in optlist:
-		o = o[2:] # strip the leading --
-
-		if o in configOptions:
-		  val = getattr(self, o)
-		  # check to see if the current/default value is a boolean. If so,
-		  # then the value is true if specified as a flag; otherwise, convert
-		  # the option value to a bool.
-		  if val.__class__ == bool:
-			if (a == None or len(a) == 0) :
-			  val = True
-			else:
-			  val = (a.strip().lower() == "true")
-		  else: 
-			val = a
-		  setattr(self, o, val)
-
-	# ---------------------
-        # usage text for help
-	# ---------------------
-	def usage(self):
-		
-		logging.debug("The required fields are: server, user and (password or xpassword)")
-		logging.debug("eg:")
-		logging.debug("python get_imap_email.py --server=<mail server name> --user=<user name> --password=<unencrypted password> OR")
-		logging.debug("python get_imap_email.py --server=<mail server name> --user=<user name> --xpassword=<encrypted password>")
-		logging.debug("Other parameters that can also be supplied. Refer the default/imap.conf file for details")
-		
-
-	# ---------------------------------------------------------
-        # Helper function for mapping folder to UID
-        # Returns the cached id for the given mailbox, or zero if
-        # we've never looked in it before
-	# ---------------------------------------------------------
-	def getCacheIDForMailbox(self, box):
-		if not self.noCache:
-			
-			#If we are here it means we have to extract the last used UID from splunk...
-			import splunk.auth as au
-			import splunk.search as se
-			import splunk
-			import httplib2
-			import time
-			import string
-			
-			if self.splunkxpassword:
-				try:
-					p = subprocess.Popen('openssl bf -d -a -pass file:"%s"' % (os.path.join(os.environ['SPLUNK_HOME'],'etc','auth', 'splunk.secret')), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-					self.splunkpassword = p.communicate(self.splunkxpassword + '\n')[0]
-				except Exception as e:
-					if self.debug:
-						logging.error(e)
-						print(traceback.print_exc(file=sys.stderr))
-					raise ConfigError('Could not decrypt splunkxpassword')
-		
-			logging.debug("decrypted splunk password")
-			
-			splunk.mergeHostPath(self.splunkHostPath, True)
-			try:
-				key = au.getSessionKey(self.splunkuser, self.splunkpassword)
-			except httplib2.ServerNotFoundError as e:
-				raise LoginError("Unable to find the server at %s" % self.splunkHostPath)
-			except Exception as e:
-				raise LoginError("userid/password combination for splunk user is invalid...")
-			
-			if not key:
-				raise LoginError("userid/password combination for splunk user is invalid...")
-			
-			if box[0] == "'" or box[0] == '"':
-				ss = 'search index=mail mailbox=' + box + ' | head 1 | stats max(Date)'
-			else:
-				ss = 'search index=mail mailbox="' + box + '" | head 1 | stats max(Date)'
-
-			job = se.dispatch(ss, sessionKey=key)
-
-			start = datetime.datetime.now()
-
-			logging.debug("dispatched search = " + ss)
-			logging.debug("dispatched job to splunk through the REST API. Waiting for response...")
-
-			while not job.isDone:
-				time.sleep(1)
-				logging.debug("*** waiting ")
-				now = datetime.datetime.now()
-				#if (now - start).seconds > self.timeout:
-				if int((now - start).seconds) > int(self.timeout):
-					logging.debug("REST response took more than %s seconds, timing out...using default UID of 0 i.e. same as noCache" % str(self.timeout))
-					break
-
-
-			#if we have caching on, and we run this for the first time, the result will not have any key like UID
-			#Hence it will throw a KeyError or IndexError. Just ignore that error and return 0
-			try:
-				retVal = str(job.results[0]['max(Date)'])
-				logging.debug(" got back " + str(retVal))
-			except Exception as e:
-				logging.debug(str(e))
-				logging.debug(" mailbox was empty ")
-				retVal = "" 
-
-			job.cancel()
-
-			return retVal
-			
-
-		else:
-		   return ""
-
-	# --------------------------------------------------
-        # Method will login and iterate through each folder 
-	# --------------------------------------------------
-	def getMail(self):
-		logging.debug("VERSION = " + str(self.version))
-	
-		# If the user supplied encrypted password then we need to unencrypt.
-		if self.xpassword:
-			try:
-				p = subprocess.Popen('openssl bf -d -a -pass file:"%s"' % (os.path.join(os.environ['SPLUNK_HOME'],'etc','auth', 'splunk.secret')), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-				self.password = p.communicate(self.xpassword + '\n')[0]
-			except Exception as e:
-				if self.debug:
-					logging.debug(e)
-					print(traceback.print_exc(file=sys.stderr))
-				raise ConfigError('Could not decrypt xpassword')
-
-		# Try and login
-		try:
-			if self.port:
-				if self.useSSL:
-					M = imaplib.IMAP4_SSL(self.server,int(self.port))
-				else:
-					M = imaplib.IMAP4(self.server,int(self.port))
-			else:
-				if self.useSSL:
-					M = imaplib.IMAP4_SSL(self.server)
-				else:
-					M = imaplib.IMAP4(self.server)
-					
-			M.login(self.user, self.password)
-		except Exception as e:
-			if self.debug:
-				logging.debug(e)
-				print(traceback.print_exc(file=sys.stderr))
-			raise LoginError('Could not log into server: %s with password provided' % self.server)
-
-		try:	   
-		  folder_list = []
-	  
-		  # See if we need to interate all folders put them into a list
-		  if self.folders.lower() == "all":
-			  result,list = M.list();
-			  for f in list[:]:
-				  x = f.split()
-				  mailbox = " ".join(x[2:])
-				  folder_list.append(mailbox)
-		  
-		  # If the user supplied a list of mailboxes, split them up and put in list
-		  elif not self.folders == "": 
-			  if self.folders.find(",") > -1:
-				  folder_list = self.folders.split(",")
-			  else:
-				  folder_list.append(self.folders)
-		  else:
-			  folder_list = ["*"]
-		 
-		  # Run though each of the mailboxes
-		  for i in folder_list:
-			self.getMailbox(M, i)
-
-		except LoginError as e:
-			if self.debug:
-				logging.debug(e)		 
-				print(traceback.print_exc(file=sys.stderr))
-			raise e
-		except ConfigError as e:
-			if self.debug:
-				logging.debug(e)		 
-				print(traceback.print_exc(file=sys.stderr))
-			M.logout()
-			raise e
-		except Exception as e:
-			if self.debug:
-				logging.debug(e)		 
-				print(traceback.print_exc(file=sys.stderr))
-			logging.error("ERROR - trying to login to server and get folders")
-		
-		  
-	
-	# ---------------------------------------------------
-        # Method will login and iterate through each folder.
-	# ---------------------------------------------------
-	def getMailbox(self, M, box):
-	
-		box = box.replace('"/" ', '')
-		box = box.strip()
-		logging.debug("about to dump mailbox %s" % (box))
-
-		# new method
-		# search for the last internal time
-		# get messages since that day of the latest internal time
-		# get internal time for each message
-		# skip ahead until the internal time is matching
-		# dedupe
-		# for all new messages index.
-
-
-		try:
-		  # get message id we read up to last time (0 first time)
-		  latestTime = self.getCacheIDForMailbox(box)
-		  logging.debug("using last time of " + latestTime)
-
-		  # Select the mail box at hand, or * for defult
-		  if box == "*":
-			  resCode, resText = M.select()
-		  else:
-			  resCode, resText = M.select(box)
-
-			  endid = int(resText[0])
-		  if endid < 1:
-			  return
-
-		  # each mailbox is its own source. i
-		  # We use the ***SPLUNK*** header processor trick to change sources for each event
-		  # each of the below must be on its own line, thus the breaker text after.
-		  print("***SPLUNK*** source="+box + " sourcetype=imap host=" + self.server)
-		  print(self.END_IMAP_BREAKER)
-
-		  if latestTime == "":
-			  self.getAllMail(M, box, endid)
-		  else:
-			  self.getLatestMail(latestTime, M, box, endid)
-
-		  # if delete when done, clean it up
-		  if self.deleteWhenDone:
-			  M.expunge()
-		  if resCode == 'NO':
-			  raise ConfigError("Folder name %s does not exist..." % box)
-
-		except Exception as e:
-			if self.debug:
-				logging.debug(e)		 
-				print(traceback.print_exc(file=sys.stderr))
-			logging.error("ERROR - trying to select mailbox")
-
-
-		try:
-		  M.close()
-		except:
-		  pass
-
-	# -------------------------------
-        # Download all email
-	# ------------------------------
-	def getAllMail(self, M, box, endid):
-
-		chunksize = 200
-		counter = 1
-		logging.debug("about to get all mail up to counter :" + str(endid)) 
- 
-		try:
-
-			while counter <= endid:
-				searchStr = "(" + self.imapSearch + " " + str(counter) + ":" + str(counter+chunksize) + ")"
-				logging.debug("about so imap search with : " + searchStr)
-				counter = counter + chunksize
-
-				typ, data = M.search(None, searchStr)
-				ids = data[0].split()
-				if len(ids) < 1:
-					continue;
-				logging.debug("returned from search with " + str(len(ids)) + "ids")
-				logging.debug("id return from search : " + str(ids))
-
-				# for each message id....
-				for num in ids:
-					try:
-						self.fetchMessage(M, box, num, "")
-					except Exception as e:
-						logging.debug("ERROR trying to fetrucn message id: " + num)
-						if self.debug:
-							logging.debug(e)
-							print(traceback.print_exc(file=sys.stderr))
-	
-		except:
-			if self.debug:
-				print(traceback.print_exc(file=sys.stderr))
-			logging.error("ERROR - trying to search mailbox")
-
-
-	# ---------------------------------------------------
-	def getInternalDate(self, M, box, num):
-		dstr = ''
-		try:
-			typ, data = M.fetch(num, '(INTERNALDATE)')
-			dates = data[0]
-			begin = dates.find('"')
-			end = dates.rfind('"')
-			dstr = dates[begin+1:end]
-		except:
-			dstr = '' 
-			logging.debug("ERROR - could not get date for message - this is a problem")
-
-		return dstr
-
-
-	# ------------------------------------------------------------------
-        # get the messages for the day of last time.
-        # unfortunately it looks like the granularity of search is per day.
-        # so we read starting the day and then skip ahead, kinda lame.
-        # ------------------------------------------------------------------
-	def getLatestMail( self, latestTimeStr, M, box, endid):
-		logging.debug("About to get lastest mail sinze " + latestTimeStr )
-
-		# convert to a datetime so we can compare
-		lastDateTime = datetime.datetime.strptime(latestTimeStr[:-6],"%d-%b-%Y %H:%M:%S")
-		logging.debug("datetime for latest is " + str(lastDateTime))
-
-		# strip off the time, since imap only does day granularity
-		justDate = latestTimeStr.split(' ')[0]
-		searchStr = "(" + self.imapSearch + " SINCE " + justDate + ")"
-		logging.debug("About to search IMAP using ; " + searchStr)
-		typ, data = M.search(None, searchStr)
-		logging.debug("Got back the following for the day " +  str(data) );
-
-		ids = data[0].split()
-		logging.debug("returned from search with " + str(len(ids)) + "ids")
-		logging.debug("id return from search : " + str(ids))
-
-		# if empty there is no new data, bail.
-		if len(ids) < 1:
-			logging.debug("Got zero ids, doing nothihng")
-			return;
-
-		# for each new message id
-		for num in ids:
-			# get message date so that we can compare to see if is newer 
-			dstr = self.getInternalDate(M, box, num)
-			if dstr == "":
-				continue
- 
-			# convert message date to datetime so we can compare
-			msgDateTime = datetime.datetime.strptime(dstr[:-6],"%d-%b-%Y %H:%M:%S")
-			logging.debug("datetime for message " + str(msgDateTime))
-
-			# see if we are caught up yet...
-			if lastDateTime < msgDateTime:
-				# this is a new message, print it out 
-				self.fetchMessage(M, box, num, dstr)
-
-	# ------------------------------------------------
-        # print body message to STDOUT for indexing
-        # ------------------------------------------------
-	def printBody( self, message, body, cstr ):
-		if 'Content-Transfer-Encoding' in message and message.get('Content-Transfer-Encoding')=='base64':
-			try:
-				body = base64.b64decode(body)
-				#cstr.write('decoded base64 successfully' + '\n')
-			except:
-				cstr.write('WARNING - could not decode base64' + '\n')
-                #pj suggested improvement by vragosta to get rid of occasional " =20" at end of lines.
-		#cstr.write(body + '\n')
-                cstr.write(quopri.decodestring(body) + '\n')
-
-	# -------------------------------------------------
-        # Get and print to STDOUT the mail message
-        # -------------------------------------------------
-	def fetchMessage( self, M, box, num , dstr):
-		cstr = io.StringIO()
-		try:
-			  
-			# get UID
-			typ, data = M.fetch(num, 'UID')
-			uid = int(data[0].split()[0])
-			lastUID = uid
-	 
-			if dstr == "":
-				dstr = self.getInternalDate(M, box, num)
-
-			# get message body
-			try:
-				typ, data = M.fetch(num, '(BODY.PEEK[])')
-				#typ, data = M.fetch(num, '(RFC822)')
-				body = data[0][1]
-			except:
-				logging.debug("Fetch error" + num )
-				if self.debug:
-					logging.debug(e)
-					print(traceback.print_exc(file=sys.stderr))
-
-
-
-			# get message size
-			typ, data = M.fetch(num, '(RFC822.SIZE)')
-			size = data[0].split()
-			size = size[-1].replace(')', '')
-	
-			# create message object from the body
-			message = email.message_from_string(body)
-	
-			# Try printing out the date first, we will use this to break the events.
-			if dstr == '':
-			  dstr = 'no date in message'
-			  if 'date' in message:
-				  dstr = message['date']
-			  elif 'Date' in message:
-				  dstr = message['Date']
-			  elif 'DATE' in message:
-				  dstr = message['DATE']
-
-			cstr.write('Date = "' + dstr + '"\n')
-		  
-
-			for k, v in message.items():
-				if k == 'date' or k == 'Date':
-				  continue
-				if not self.fullHeaders:
-					lk = k.lower()
-					if lk == 'from' or lk == 'to' or lk == 'subject' or lk == 'date' or lk == 'cc':
-						cstr.write(k + ' = "' + v.replace('"', '').replace('\n', '').replace('\r', '') + '"\n')
-				else:
-					cstr.write(k + ' = "' + v.replace('"', '').replace('\n', '').replace('\r', '') + '"\n')
-	
-			# include size and name of folder since they are not part of header
-			# interestingly, sometimes these come back quoted - so check.
-			if box[0]=="'" or box[0]=='"':
-			  cstr.write('mailbox = ' + box + '\n')
-			else:
-			  cstr.write('mailbox = "' + box + '"\n')
-
-			cstr.write("size = "+size + '\n')
-
-			# If option includeBody is True then print STOUT the mail body. 
-			if self.includeBody:
-                                # print the body separator line.
-				cstr.write(self.body_separator + '\n')
-
-				# This option is old and not needed. We auto set sourcetype in inputs.conf now.
-				if self.useBodySourceType:
-				   # hardcoded the changing of sourcetype to mailbody. 
-					# customers can change the procssing of mailbody's differently in props.conf
-					cstr.write("EndIMAPHeader" + '\n')
-					cstr.write("sourcetype=" + self.bodySourceType + '\n')
-			  
-					# if we are breaking up the event we need to spit out a timestamp.
-					cstr.write("date = " + message['date'] + '\n')
-
-
-			  # if the message is not multipart - its text so just dump it out.
-				#for key in message.keys():
-				#	cstr.write("***key " + key + "	** value=" + message.get(key)+ '\n')
-				if not message.is_multipart():
-					body = message.get_payload()
-					self.printBody(message, body, cstr)
-				else:
-				  # if it is multipart, then only dump parts whose type is
-				  # in the mimeTypes list.
-				  for part in message.walk():
-					if part.get_content_type() in self._mimeTypesList:
-						body = part.get_payload(decode=True)
-						self.printBody( message, body, cstr )
-                        # else, we are not indexing the message body, so do nothing.
-                        # just print debug data only.
-			else:
-				if self.debug:
-					for part in message.walk():
-						cstr.write("ContentType :	" + part.get_content_type() + '\n')
-                                                logging.debug("No message context to print as value includeBody is set to False" + '\n')
-
-			cstr.write(self.END_IMAP_BREAKER)
-
-			if self.useBodySourceType:
-			  # set us back to mail sourcetype
-			  cstr.write("***splunk*** sourcetype=" + self.headerSourceType + '\n')
-			print(cstr.getvalue())
-
-			# if delete when done, then mark the message
-			if self.deleteWhenDone:
-				M.store(num, '+Flags', '(\Deleted)')
-
-
-		except Exception as e:
-			logging.debug("1. Failed to get and print message with UID " + num )
-			if self.debug:
-				logging.debug(e)
-				print(traceback.print_exc(file=sys.stderr))
-			logging.debug("2. Failed to get and print message with UID " + num )
-
-			
+    # -------------------
+    # default values.
+    # -------------------
+    def __init__(self):
+        # initialize all of the configuration fields with default values that
+        # will be used on the off chance that they don't appear in imap.conf
+        self.server = ""        # this is required
+        self.user = ""          # this is required
+        self.password = ""      # and either this...
+        self.xpassword = ""     # ...or this is also required
+        self.port = 993
+        self.folders = 'all'
+        self.imapSearch = 'UNDELETED'
+        self.fullHeaders = False
+        self.includeBody = True
+        self.mimeTypes = 'text/plain'
+        self._mimeTypesList = []             # split list of mime types
+        self.splunkuser = 'admin'
+        self.splunkpassword = 'changeme'     # default splunk admin password
+        self.splunkxpassword = ''
+        self.splunkHostPath = 'https://localhost:8089'
+        self.timeout = 10
+        self.noCache = False
+        self.debug = False
+        self.useSSL = True
+        self.deleteWhenDone = False
+        self.END_IMAP_BREAKER = 'EndIMAPMessage'
+        self.bodySourceType = 'imapbody'
+        self.body_separator = '____________________  Message Body  ____________________'
+        self.headerSourceType = 'imap'
+        self.useBodySourceType = False
+        self.version = "2.0"
+
+
+    # -----------------------------------
+    # read in all options and settings.
+    # -----------------------------------
+    def initFromOptlist(self, optlist):
+        # First read settings in imap.conf, if it exists...
+        self.readConfig()
+
+        # ...now, for debugging and backward compat, allow command line
+        # settings to override...
+        self.readOptlist(optlist)
+
+        if self.debug:
+            logging.basicConfig(level=logging.DEBUG)
+            keys = sorted(self.__dict__.keys())
+            for k in keys:
+                if k.startswith("_"): continue
+                logging.debug(k + "=" + str(self.__dict__[k]))
+        else:
+            logging.basicConfig(level=logging.ERROR)
+
+        # check min required args
+        if self.server == "" or self.user == "" or ( self.password == "" and self.xpassword =="" ):
+            self.usage()
+            #sys.exit()
+            raise ConfigError
+
+        # pre-parse the mime types list
+        if self.mimeTypes.find(",") > -1:
+            self._mimeTypesList = self.mimeTypes.split(",")
+        else:
+            self._mimeTypesList.append(self.mimeTypes)
+
+        # deleteWhenDone overrides any caching. Our assumption is that all messages in the box are new each time
+        if self.deleteWhenDone:
+            self.noCache = True
+
+    # -----------------------------------
+    # - Read settings from imap.conf(s)
+    # -----------------------------------
+    def readConfig(self):
+        path = ''
+        if os.path.exists(configLocalFileName):
+            path = configLocalFileName
+        elif os.path.exists(configDefaultFileName):
+            path = configDefaultFileName
+        else:
+            return
+        config = RawConfigParser()
+        config.read(path)
+        for o in configOptions:
+            if config.has_option(configSectionName, o):
+                val = getattr(self, o)
+                # check to see if the current/default value is a boolean; if so,
+                # makes user user supplied value is a bool, will convert string to bool.
+                # ie. makes 0 = False and 1 = True
+                if val.__class__ == bool:
+                    val = (config.get(configSectionName, o).strip().lower() == "true")
+                    if config.get(configSectionName, o) == "1":
+                        val = True
+                    if config.get(configSectionName, o) == "0":
+                        val = False
+                else:
+                    val = config.get(configSectionName, o)
+                setattr(self, o, val)
+
+
+    # ----------------------------------------------------------------
+    # Read settings from the command line.  We support command
+    # line args mainly for backwards compat and for quick debugging;
+    # users should be encouraged to use the imap.conf file instead
+    # ----------------------------------------------------------------
+    def readOptlist(self, optlist):
+        for o, a in optlist:
+            o = o[2:] # strip the leading --
+
+            if o in configOptions:
+                val = getattr(self, o)
+                # check to see if the current/default value is a boolean. If so,
+                # then the value is true if specified as a flag; otherwise, convert
+                # the option value to a bool.
+                if val.__class__ == bool:
+                    if (a == None or len(a) == 0) :
+                        val = True
+                    else:
+                        val = (a.strip().lower() == "true")
+                else:
+                    val = a
+                setattr(self, o, val)
+
+    # ---------------------
+    # usage text for help
+    # ---------------------
+    def usage(self):
+
+        logging.debug("The required fields are: server, user and (password or xpassword)")
+        logging.debug("eg:")
+        logging.debug("python get_imap_email.py --server=<mail server name> --user=<user name> --password=<unencrypted password> OR")
+        logging.debug("python get_imap_email.py --server=<mail server name> --user=<user name> --xpassword=<encrypted password>")
+        logging.debug("Other parameters that can also be supplied. Refer the default/imap.conf file for details")
+
+
+    # ---------------------------------------------------------
+    # Helper function for mapping folder to UID
+    # Returns the cached id for the given mailbox, or zero if
+    # we've never looked in it before
+    # ---------------------------------------------------------
+    def getCacheIDForMailbox(self, box):
+        if not self.noCache:
+
+                    #If we are here it means we have to extract the last used UID from splunk...
+            import splunk.auth as au
+            import splunk.search as se
+            import splunk
+            import httplib2
+            import time
+            import string
+
+            if self.splunkxpassword:
+                try:
+                    p = subprocess.Popen('openssl bf -d -a -pass file:"%s"' % (os.path.join(os.environ['SPLUNK_HOME'],'etc','auth', 'splunk.secret')), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+                    self.splunkpassword = p.communicate(self.splunkxpassword + '\n')[0]
+                except Exception as e:
+                    if self.debug:
+                        logging.error(e)
+                        print(traceback.print_exc(file=sys.stderr))
+                    raise ConfigError('Could not decrypt splunkxpassword')
+
+            logging.debug("decrypted splunk password")
+
+            splunk.mergeHostPath(self.splunkHostPath, True)
+            try:
+                key = au.getSessionKey(self.splunkuser, self.splunkpassword)
+            except httplib2.ServerNotFoundError as e:
+                raise LoginError("Unable to find the server at %s" % self.splunkHostPath)
+            except Exception as e:
+                raise LoginError("userid/password combination for splunk user is invalid...")
+
+            if not key:
+                raise LoginError("userid/password combination for splunk user is invalid...")
+
+            if box[0] == "'" or box[0] == '"':
+                ss = 'search index=mail mailbox=' + box + ' | head 1 | stats max(Date)'
+            else:
+                ss = 'search index=mail mailbox="' + box + '" | head 1 | stats max(Date)'
+
+            job = se.dispatch(ss, sessionKey=key)
+
+            start = datetime.datetime.now()
+
+            logging.debug("dispatched search = " + ss)
+            logging.debug("dispatched job to splunk through the REST API. Waiting for response...")
+
+            while not job.isDone:
+                time.sleep(1)
+                logging.debug("*** waiting ")
+                now = datetime.datetime.now()
+                #if (now - start).seconds > self.timeout:
+                if int((now - start).seconds) > int(self.timeout):
+                    logging.debug("REST response took more than %s seconds, timing out...using default UID of 0 i.e. same as noCache" % str(self.timeout))
+                    break
+
+
+            #if we have caching on, and we run this for the first time, the result will not have any key like UID
+            #Hence it will throw a KeyError or IndexError. Just ignore that error and return 0
+            try:
+                retVal = str(job.results[0]['max(Date)'])
+                logging.debug(" got back " + str(retVal))
+            except Exception as e:
+                logging.debug(str(e))
+                logging.debug(" mailbox was empty ")
+                retVal = ""
+
+            job.cancel()
+
+            return retVal
+
+
+        else:
+            return ""
+
+    # --------------------------------------------------
+    # Method will login and iterate through each folder
+    # --------------------------------------------------
+    def getMail(self):
+        logging.debug("VERSION = " + str(self.version))
+
+        # If the user supplied encrypted password then we need to unencrypt.
+        if self.xpassword:
+            try:
+                p = subprocess.Popen('openssl bf -d -a -pass file:"%s"' % (os.path.join(os.environ['SPLUNK_HOME'],'etc','auth', 'splunk.secret')), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+                self.password = p.communicate(self.xpassword + '\n')[0]
+            except Exception as e:
+                if self.debug:
+                    logging.debug(e)
+                    print(traceback.print_exc(file=sys.stderr))
+                raise ConfigError('Could not decrypt xpassword')
+
+        # Try and login
+        try:
+            if self.port:
+                if self.useSSL:
+                    M = imaplib.IMAP4_SSL(self.server,int(self.port))
+                else:
+                    M = imaplib.IMAP4(self.server,int(self.port))
+            else:
+                if self.useSSL:
+                    M = imaplib.IMAP4_SSL(self.server)
+                else:
+                    M = imaplib.IMAP4(self.server)
+
+            M.login(self.user, self.password)
+        except Exception as e:
+            if self.debug:
+                logging.debug(e)
+                print(traceback.print_exc(file=sys.stderr))
+            raise LoginError('Could not log into server: %s with password provided' % self.server)
+
+        try:
+            folder_list = []
+
+            # See if we need to interate all folders put them into a list
+            if self.folders.lower() == "all":
+                result,list = M.list();
+                for f in list[:]:
+                    x = f.split()
+                    mailbox = " ".join(x[2:])
+                    folder_list.append(mailbox)
+
+            # If the user supplied a list of mailboxes, split them up and put in list
+            elif not self.folders == "":
+                if self.folders.find(",") > -1:
+                    folder_list = self.folders.split(",")
+                else:
+                    folder_list.append(self.folders)
+            else:
+                folder_list = ["*"]
+
+            # Run though each of the mailboxes
+            for i in folder_list:
+                self.getMailbox(M, i)
+
+        except LoginError as e:
+            if self.debug:
+                logging.debug(e)
+                print(traceback.print_exc(file=sys.stderr))
+            raise e
+        except ConfigError as e:
+            if self.debug:
+                logging.debug(e)
+                print(traceback.print_exc(file=sys.stderr))
+            M.logout()
+            raise e
+        except Exception as e:
+            if self.debug:
+                logging.debug(e)
+                print(traceback.print_exc(file=sys.stderr))
+            logging.error("ERROR - trying to login to server and get folders")
+
+
+
+    # ---------------------------------------------------
+    # Method will login and iterate through each folder.
+    # ---------------------------------------------------
+    def getMailbox(self, M, box):
+
+        box = box.replace('"/" ', '')
+        box = box.strip()
+        logging.debug("about to dump mailbox %s" % (box))
+
+        # new method
+        # search for the last internal time
+        # get messages since that day of the latest internal time
+        # get internal time for each message
+        # skip ahead until the internal time is matching
+        # dedupe
+        # for all new messages index.
+
+
+        try:
+            # get message id we read up to last time (0 first time)
+            latestTime = self.getCacheIDForMailbox(box)
+            logging.debug("using last time of " + latestTime)
+
+            # Select the mail box at hand, or * for defult
+            if box == "*":
+                resCode, resText = M.select()
+            else:
+                resCode, resText = M.select(box)
+
+                endid = int(resText[0])
+            if endid < 1:
+                return
+
+            # each mailbox is its own source. i
+            # We use the ***SPLUNK*** header processor trick to change sources for each event
+            # each of the below must be on its own line, thus the breaker text after.
+            print("***SPLUNK*** source="+box + " sourcetype=imap host=" + self.server)
+            print(self.END_IMAP_BREAKER)
+
+            if latestTime == "":
+                self.getAllMail(M, box, endid)
+            else:
+                self.getLatestMail(latestTime, M, box, endid)
+
+            # if delete when done, clean it up
+            if self.deleteWhenDone:
+                M.expunge()
+            if resCode == 'NO':
+                raise ConfigError("Folder name %s does not exist..." % box)
+
+        except Exception as e:
+            if self.debug:
+                logging.debug(e)
+                print(traceback.print_exc(file=sys.stderr))
+            logging.error("ERROR - trying to select mailbox")
+
+
+        try:
+            M.close()
+        except:
+            pass
+
+    # -------------------------------
+    # Download all email
+    # ------------------------------
+    def getAllMail(self, M, box, endid):
+
+        chunksize = 200
+        counter = 1
+        logging.debug("about to get all mail up to counter :" + str(endid))
+
+        try:
+
+            while counter <= endid:
+                searchStr = "(" + self.imapSearch + " " + str(counter) + ":" + str(counter+chunksize) + ")"
+                logging.debug("about so imap search with : " + searchStr)
+                counter = counter + chunksize
+
+                typ, data = M.search(None, searchStr)
+                ids = data[0].split()
+                if len(ids) < 1:
+                    continue;
+                logging.debug("returned from search with " + str(len(ids)) + "ids")
+                logging.debug("id return from search : " + str(ids))
+
+                # for each message id....
+                for num in ids:
+                    try:
+                        self.fetchMessage(M, box, num, "")
+                    except Exception as e:
+                        logging.debug("ERROR trying to fetrucn message id: " + num)
+                        if self.debug:
+                            logging.debug(e)
+                            print(traceback.print_exc(file=sys.stderr))
+
+        except:
+            if self.debug:
+                print(traceback.print_exc(file=sys.stderr))
+            logging.error("ERROR - trying to search mailbox")
+
+
+    # ---------------------------------------------------
+    def getInternalDate(self, M, box, num):
+        dstr = ''
+        try:
+            typ, data = M.fetch(num, '(INTERNALDATE)')
+            dates = data[0]
+            begin = dates.find('"')
+            end = dates.rfind('"')
+            dstr = dates[begin+1:end]
+        except:
+            dstr = ''
+            logging.debug("ERROR - could not get date for message - this is a problem")
+
+        return dstr
+
+
+    # ------------------------------------------------------------------
+    # get the messages for the day of last time.
+    # unfortunately it looks like the granularity of search is per day.
+    # so we read starting the day and then skip ahead, kinda lame.
+    # ------------------------------------------------------------------
+    def getLatestMail( self, latestTimeStr, M, box, endid):
+        logging.debug("About to get lastest mail sinze " + latestTimeStr )
+
+        # convert to a datetime so we can compare
+        lastDateTime = datetime.datetime.strptime(latestTimeStr[:-6],"%d-%b-%Y %H:%M:%S")
+        logging.debug("datetime for latest is " + str(lastDateTime))
+
+        # strip off the time, since imap only does day granularity
+        justDate = latestTimeStr.split(' ')[0]
+        searchStr = "(" + self.imapSearch + " SINCE " + justDate + ")"
+        logging.debug("About to search IMAP using ; " + searchStr)
+        typ, data = M.search(None, searchStr)
+        logging.debug("Got back the following for the day " +  str(data) );
+
+        ids = data[0].split()
+        logging.debug("returned from search with " + str(len(ids)) + "ids")
+        logging.debug("id return from search : " + str(ids))
+
+        # if empty there is no new data, bail.
+        if len(ids) < 1:
+            logging.debug("Got zero ids, doing nothihng")
+            return;
+
+        # for each new message id
+        for num in ids:
+            # get message date so that we can compare to see if is newer
+            dstr = self.getInternalDate(M, box, num)
+            if dstr == "":
+                continue
+
+            # convert message date to datetime so we can compare
+            msgDateTime = datetime.datetime.strptime(dstr[:-6],"%d-%b-%Y %H:%M:%S")
+            logging.debug("datetime for message " + str(msgDateTime))
+
+            # see if we are caught up yet...
+            if lastDateTime < msgDateTime:
+                # this is a new message, print it out
+                self.fetchMessage(M, box, num, dstr)
+
+    # ------------------------------------------------
+    # print body message to STDOUT for indexing
+    # ------------------------------------------------
+    def printBody( self, message, body, cstr ):
+        if 'Content-Transfer-Encoding' in message and message.get('Content-Transfer-Encoding')=='base64':
+            try:
+                body = base64.b64decode(body)
+                #cstr.write('decoded base64 successfully' + '\n')
+            except:
+                cstr.write('WARNING - could not decode base64' + '\n')
+        #pj suggested improvement by vragosta to get rid of occasional " =20" at end of lines.
+        #cstr.write(body + '\n')
+        cstr.write(quopri.decodestring(body) + '\n')
+
+    # -------------------------------------------------
+    # Get and print to STDOUT the mail message
+    # -------------------------------------------------
+    def fetchMessage( self, M, box, num , dstr):
+        cstr = io.StringIO()
+        try:
+
+            # get UID
+            typ, data = M.fetch(num, 'UID')
+            uid = int(data[0].split()[0])
+            lastUID = uid
+
+            if dstr == "":
+                dstr = self.getInternalDate(M, box, num)
+
+            # get message body
+            try:
+                typ, data = M.fetch(num, '(BODY.PEEK[])')
+                #typ, data = M.fetch(num, '(RFC822)')
+                body = data[0][1]
+            except:
+                logging.debug("Fetch error" + num )
+                if self.debug:
+                    logging.debug(e)
+                    print(traceback.print_exc(file=sys.stderr))
+
+
+
+            # get message size
+            typ, data = M.fetch(num, '(RFC822.SIZE)')
+            size = data[0].split()
+            size = size[-1].replace(')', '')
+
+            # create message object from the body
+            message = email.message_from_string(body)
+
+            # Try printing out the date first, we will use this to break the events.
+            if dstr == '':
+                dstr = 'no date in message'
+                if 'date' in message:
+                    dstr = message['date']
+                elif 'Date' in message:
+                    dstr = message['Date']
+                elif 'DATE' in message:
+                    dstr = message['DATE']
+
+            cstr.write('Date = "' + dstr + '"\n')
+
+
+            for k, v in message.items():
+                if k == 'date' or k == 'Date':
+                    continue
+                if not self.fullHeaders:
+                    lk = k.lower()
+                    if lk == 'from' or lk == 'to' or lk == 'subject' or lk == 'date' or lk == 'cc':
+                        cstr.write(k + ' = "' + v.replace('"', '').replace('\n', '').replace('\r', '') + '"\n')
+                else:
+                    cstr.write(k + ' = "' + v.replace('"', '').replace('\n', '').replace('\r', '') + '"\n')
+
+            # include size and name of folder since they are not part of header
+            # interestingly, sometimes these come back quoted - so check.
+            if box[0]=="'" or box[0]=='"':
+                cstr.write('mailbox = ' + box + '\n')
+            else:
+                cstr.write('mailbox = "' + box + '"\n')
+
+            cstr.write("size = "+size + '\n')
+
+            # If option includeBody is True then print STOUT the mail body.
+            if self.includeBody:
+                # print the body separator line.
+                cstr.write(self.body_separator + '\n')
+
+                # This option is old and not needed. We auto set sourcetype in inputs.conf now.
+                if self.useBodySourceType:
+                   # hardcoded the changing of sourcetype to mailbody.
+                    # customers can change the procssing of mailbody's differently in props.conf
+                    cstr.write("EndIMAPHeader" + '\n')
+                    cstr.write("sourcetype=" + self.bodySourceType + '\n')
+
+                    # if we are breaking up the event we need to spit out a timestamp.
+                    cstr.write("date = " + message['date'] + '\n')
+
+
+                # if the message is not multipart - its text so just dump it out.
+                #for key in message.keys():
+                #       cstr.write("***key " + key + "  ** value=" + message.get(key)+ '\n')
+                if not message.is_multipart():
+                    body = message.get_payload()
+                    self.printBody(message, body, cstr)
+                else:
+                    # if it is multipart, then only dump parts whose type is
+                    # in the mimeTypes list.
+                    for part in message.walk():
+                        if part.get_content_type() in self._mimeTypesList:
+                            body = part.get_payload(decode=True)
+                            self.printBody( message, body, cstr )
+            # else, we are not indexing the message body, so do nothing.
+            # just print debug data only.
+            else:
+                if self.debug:
+                    for part in message.walk():
+                        cstr.write("ContentType :       " + part.get_content_type() + '\n')
+                        logging.debug("No message context to print as value includeBody is set to False" + '\n')
+
+            cstr.write(self.END_IMAP_BREAKER)
+
+            if self.useBodySourceType:
+                # set us back to mail sourcetype
+                cstr.write("***splunk*** sourcetype=" + self.headerSourceType + '\n')
+            print(cstr.getvalue())
+
+            # if delete when done, then mark the message
+            if self.deleteWhenDone:
+                M.store(num, '+Flags', '(\Deleted)')
+
+
+        except Exception as e:
+            logging.debug("1. Failed to get and print message with UID " + num )
+            if self.debug:
+                logging.debug(e)
+                print(traceback.print_exc(file=sys.stderr))
+            logging.debug("2. Failed to get and print message with UID " + num )
+
+
 # --------------------------------------------------------------
 # - parse all program options
 # --------------------------------------------------------------
 def parseArgs():
-	imapProc = IMAPProcessor()
+    imapProc = IMAPProcessor()
 
-	optlist = None
-	try:
-	  optlist, args = getopt.getopt(sys.argv[1:], '?',['version', 'server=','user=', 'password=', 'xpassword=', 'port=', 'folders=', 'imapSearch=', 'fullHeaders=', 'includeBody=', 'mimeTypes=', 'splunkuser=', 'splunkpassword=', 'splunkxpassword=', 'splunkHostPath=', 'timeout=', 'noCache', 'debug', 'useSSL=', 'deleteWhenDone='])
-	  if 'version' in args:
-		print(sys.argv[0], "version =",  str(imapProc.version))
-		return
-	  imapProc.initFromOptlist(optlist)
-	except getopt.error as val:
-	  logging.error("str(val) # tell them what was wrong")
-	  imapProc.usage()
-	  raise ConfigError("Incorrect usage...")
-	  
-	#- Do the work....	 
-	imapProc.getMail()
-		
+    optlist = None
+    try:
+        optlist, args = getopt.getopt(sys.argv[1:], '?',['version', 'server=','user=', 'password=', 'xpassword=', 'port=', 'folders=', 'imapSearch=', 'fullHeaders=', 'includeBody=', 'mimeTypes=', 'splunkuser=', 'splunkpassword=', 'splunkxpassword=', 'splunkHostPath=', 'timeout=', 'noCache', 'debug', 'useSSL=', 'deleteWhenDone='])
+        if 'version' in args:
+            print(sys.argv[0], "version =",  str(imapProc.version))
+            return
+        imapProc.initFromOptlist(optlist)
+    except getopt.error as val:
+        logging.error("str(val) # tell them what was wrong")
+        imapProc.usage()
+        raise ConfigError("Incorrect usage...")
+
+    #- Do the work....
+    imapProc.getMail()
+
 
 # --------------------------------------------------------------
 # - Start script
 # --------------------------------------------------------------
 if __name__ == '__main__':
-	
-	parseArgs()
+
+    parseArgs()

--- a/bin/get_imap_email.py
+++ b/bin/get_imap_email.py
@@ -246,7 +246,7 @@ class IMAPProcessor(object):
 			
 			if self.splunkxpassword:
 				try:
-					p = subprocess.Popen('openssl bf -d -a -pass file:%s' % (os.path.join(os.environ['SPLUNK_HOME'],'etc','auth', 'splunk.secret')), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+					p = subprocess.Popen('openssl bf -d -a -pass file:"%s"' % (os.path.join(os.environ['SPLUNK_HOME'],'etc','auth', 'splunk.secret')), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 					self.splunkpassword = p.communicate(self.splunkxpassword + '\n')[0]
 				except Exception, e:
 					if self.debug:
@@ -316,7 +316,7 @@ class IMAPProcessor(object):
 		# If the user supplied encrypted password then we need to unencrypt.
 		if self.xpassword:
 			try:
-				p = subprocess.Popen('openssl bf -d -a -pass file:%s' % (os.path.join(os.environ['SPLUNK_HOME'],'etc','auth', 'splunk.secret')), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+				p = subprocess.Popen('openssl bf -d -a -pass file:"%s"' % (os.path.join(os.environ['SPLUNK_HOME'],'etc','auth', 'splunk.secret')), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 				self.password = p.communicate(self.xpassword + '\n')[0]
 			except Exception, e:
 				if self.debug:

--- a/bin/get_imap_email.py
+++ b/bin/get_imap_email.py
@@ -128,7 +128,7 @@ class IMAPProcessor(object):
         self.body_separator = '____________________  Message Body  ____________________'
         self.headerSourceType = 'imap'
         self.useBodySourceType = False
-        self.version = "2.0"
+        self.version = "2.0.4"
 
 
     # -----------------------------------

--- a/bin/get_imap_email.py
+++ b/bin/get_imap_email.py
@@ -128,7 +128,7 @@ class IMAPProcessor(object):
         self.body_separator = '____________________  Message Body  ____________________'
         self.headerSourceType = 'imap'
         self.useBodySourceType = False
-        self.version = "2.0.4"
+        self.version = "2.0.5"
 
 
     # -----------------------------------

--- a/bin/get_imap_email.py
+++ b/bin/get_imap_email.py
@@ -617,9 +617,9 @@ class IMAPProcessor(object):
 				if not self.fullHeaders:
 					lk = string.lower(k)
 					if lk == 'from' or lk == 'to' or lk == 'subject' or lk == 'date' or lk == 'cc':
-						cstr.write(k +	' = "' + string.replace(v,'"','') + '"\n')
+						cstr.write(k +	' = "' + string.replace(v,'"','').replace('\n', '').replace('\r', '') + '"\n')
 				else:
-					cstr.write(k +	' = "' + string.replace(v,'"','') + '"\n')
+					cstr.write(k +	' = "' + string.replace(v,'"','').replace('\n', '').replace('\r', '') + '"\n')
 	
 			# include size and name of folder since they are not part of header
 			# interestingly, sometimes these come back quoted - so check.

--- a/bin/imap_python_handler.py
+++ b/bin/imap_python_handler.py
@@ -51,13 +51,13 @@ class IMAPHandler(admin.MConfigHandler):
     settings = self.callerArgs.copy()
     passwdProvided = False
 
-    if 'password' in self.callerArgs.data.keys() and self.callerArgs['password']:
+    if 'password' in self.callerArgs.data and self.callerArgs['password']:
        passwdProvided = True
-    elif 'xpassword' in self.callerArgs.data.keys() and self.callerArgs['xpassword']:
+    elif 'xpassword' in self.callerArgs.data and self.callerArgs['xpassword']:
        passwdProvided = True
 
     if not passwdProvided:
-       raise admin.ArgValidationException, "Either password or xpassword must be provided"   
+       raise admin.ArgValidationException("Either password or xpassword must be provided")
      
     self.updateConf("imap", self.callerArgs.id, self.callerArgs.data);
   
@@ -71,8 +71,8 @@ class IMAPHandler(admin.MConfigHandler):
     # if the file doesn't exist, None is returned.
     if None != confDict:
       # return all these settings by populating confInfo.
-      for stanza, settings in confDict.items():
-        for key, val in settings.items():
+      for stanza, settings in list(confDict.items()):
+        for key, val in list(settings.items()):
           confInfo[stanza].append(key, val)
 
 
@@ -85,7 +85,7 @@ class IMAPHandler(admin.MConfigHandler):
     existing = admin.ConfigInfo()
     self.handleList(existing)
     if not self.callerArgs.id in existing:
-      raise admin.ArgValidationException, "Cannot remove '%s', it does not exist." % self.callerArgs.id
+      raise admin.ArgValidationException("Cannot remove '%s', it does not exist." % self.callerArgs.id)
 
     # now that we're sure, set it to disabled and write it out.
     settsDict = self.readConf("imap")[self.callerArgs.id]
@@ -102,7 +102,7 @@ class IMAPHandler(admin.MConfigHandler):
     existing = admin.ConfigInfo()
     self.handleList(existing)
     if not self.callerArgs.id in existing:
-      raise admin.ArgValidationException, "Cannot edit '%s', it does not exist." % self.callerArgs.id
+      raise admin.ArgValidationException("Cannot edit '%s', it does not exist." % self.callerArgs.id)
 
     self.updateConf("imap", self.callerArgs.id, self.callerArgs.data)
 

--- a/bin/imap_python_handler.py
+++ b/bin/imap_python_handler.py
@@ -5,106 +5,106 @@ import splunk.admin as admin
 # ----------------------------------------------
 class IMAPHandler(admin.MConfigHandler):
 
-  # -------------------------------------------------------
-  # set the read / optional arguments for the diff actions
-  # -------------------------------------------------------
-  def setup(self):
-    
-    if self.requestedAction in (admin.ACTION_CREATE,):
+    # -------------------------------------------------------
+    # set the read / optional arguments for the diff actions
+    # -------------------------------------------------------
+    def setup(self):
 
-      self.supportedArgs.addReqArg("server")
-      self.supportedArgs.addReqArg("user")
-      #actually one of password or xpassword also needs to be provided. But no easy way to do it here. 
-      #so we will perform the actual validation for this in the create handler itself 
- 
-    if self.requestedAction in (admin.ACTION_CREATE,admin.ACTION_EDIT):
+        if self.requestedAction in (admin.ACTION_CREATE,):
 
-#PJ are all of these in imap.conf??
-      self.supportedArgs.addOptArg("debug")
-      self.supportedArgs.addOptArg("folders")
-      self.supportedArgs.addOptArg("fullHeaders")
-      self.supportedArgs.addOptArg("imapSearch")
-      self.supportedArgs.addOptArg("includeBody")
-      self.supportedArgs.addOptArg("mimeTypes")
-      self.supportedArgs.addOptArg("noCache")
-      self.supportedArgs.addOptArg("password")
-      self.supportedArgs.addOptArg("port")
-      self.supportedArgs.addOptArg("splunkHostPath")
-      self.supportedArgs.addOptArg("splunkpassword")
-      self.supportedArgs.addOptArg("splunkuser")
-      self.supportedArgs.addOptArg("splunkxpassword")
-      self.supportedArgs.addOptArg("timeout")
-      self.supportedArgs.addOptArg("useSSL")
-      self.supportedArgs.addOptArg("xpassword")
+            self.supportedArgs.addReqArg("server")
+            self.supportedArgs.addReqArg("user")
+            #actually one of password or xpassword also needs to be provided. But no easy way to do it here.
+            #so we will perform the actual validation for this in the create handler itself
 
-    if self.requestedAction in (admin.ACTION_EDIT,):
-      
-      self.supportedArgs.addOptArg("server")
-      self.supportedArgs.addOptArg("user")
+        if self.requestedAction in (admin.ACTION_CREATE,admin.ACTION_EDIT):
 
-    
-  # -------------------------------- 
-  # create the imap.conf file
-  # --------------------------------
-  def handleCreate(self, confInfo):
+            # PJ are all of these in imap.conf??
+            self.supportedArgs.addOptArg("debug")
+            self.supportedArgs.addOptArg("folders")
+            self.supportedArgs.addOptArg("fullHeaders")
+            self.supportedArgs.addOptArg("imapSearch")
+            self.supportedArgs.addOptArg("includeBody")
+            self.supportedArgs.addOptArg("mimeTypes")
+            self.supportedArgs.addOptArg("noCache")
+            self.supportedArgs.addOptArg("password")
+            self.supportedArgs.addOptArg("port")
+            self.supportedArgs.addOptArg("splunkHostPath")
+            self.supportedArgs.addOptArg("splunkpassword")
+            self.supportedArgs.addOptArg("splunkuser")
+            self.supportedArgs.addOptArg("splunkxpassword")
+            self.supportedArgs.addOptArg("timeout")
+            self.supportedArgs.addOptArg("useSSL")
+            self.supportedArgs.addOptArg("xpassword")
 
-    settings = self.callerArgs.copy()
-    passwdProvided = False
+        if self.requestedAction in (admin.ACTION_EDIT,):
 
-    if 'password' in self.callerArgs.data and self.callerArgs['password']:
-       passwdProvided = True
-    elif 'xpassword' in self.callerArgs.data and self.callerArgs['xpassword']:
-       passwdProvided = True
-
-    if not passwdProvided:
-       raise admin.ArgValidationException("Either password or xpassword must be provided")
-     
-    self.updateConf("imap", self.callerArgs.id, self.callerArgs.data);
-  
-
-  # ---------------------------------------
-  # lists out all the configs in imap.conf
-  # ---------------------------------------
-  def handleList(self, confInfo):
-
-    confDict = self.readConf("imap")
-    # if the file doesn't exist, None is returned.
-    if None != confDict:
-      # return all these settings by populating confInfo.
-      for stanza, settings in list(confDict.items()):
-        for key, val in list(settings.items()):
-          confInfo[stanza].append(key, val)
+            self.supportedArgs.addOptArg("server")
+            self.supportedArgs.addOptArg("user")
 
 
-  # ---------------------------------------
-  # removes any config item from imap.conf
-  # ---------------------------------------
-  def handleRemove(self, confInfo):
+    # --------------------------------
+    # create the imap.conf file
+    # --------------------------------
+    def handleCreate(self, confInfo):
 
-    # let's make sure this thing exists, first...
-    existing = admin.ConfigInfo()
-    self.handleList(existing)
-    if not self.callerArgs.id in existing:
-      raise admin.ArgValidationException("Cannot remove '%s', it does not exist." % self.callerArgs.id)
+        settings = self.callerArgs.copy()
+        passwdProvided = False
 
-    # now that we're sure, set it to disabled and write it out.
-    settsDict = self.readConf("imap")[self.callerArgs.id]
-    settsDict["disabled"] = "true"
-    self.updateConf("imap", self.callerArgs.id, settsDict)
-  
+        if 'password' in self.callerArgs.data and self.callerArgs['password']:
+            passwdProvided = True
+        elif 'xpassword' in self.callerArgs.data and self.callerArgs['xpassword']:
+            passwdProvided = True
 
-  # ----------------------------------- 
-  # edits a config item from imap.conf
-  # -----------------------------------
-  def handleEdit(self, confInfo):
+        if not passwdProvided:
+            raise admin.ArgValidationException("Either password or xpassword must be provided")
 
-    # let's make sure this thing exists, first...
-    existing = admin.ConfigInfo()
-    self.handleList(existing)
-    if not self.callerArgs.id in existing:
-      raise admin.ArgValidationException("Cannot edit '%s', it does not exist." % self.callerArgs.id)
+        self.updateConf("imap", self.callerArgs.id, self.callerArgs.data);
 
-    self.updateConf("imap", self.callerArgs.id, self.callerArgs.data)
+
+    # ---------------------------------------
+    # lists out all the configs in imap.conf
+    # ---------------------------------------
+    def handleList(self, confInfo):
+
+        confDict = self.readConf("imap")
+        # if the file doesn't exist, None is returned.
+        if None != confDict:
+            # return all these settings by populating confInfo.
+            for stanza, settings in list(confDict.items()):
+                for key, val in list(settings.items()):
+                    confInfo[stanza].append(key, val)
+
+
+    # ---------------------------------------
+    # removes any config item from imap.conf
+    # ---------------------------------------
+    def handleRemove(self, confInfo):
+
+        # let's make sure this thing exists, first...
+        existing = admin.ConfigInfo()
+        self.handleList(existing)
+        if not self.callerArgs.id in existing:
+            raise admin.ArgValidationException("Cannot remove '%s', it does not exist." % self.callerArgs.id)
+
+        # now that we're sure, set it to disabled and write it out.
+        settsDict = self.readConf("imap")[self.callerArgs.id]
+        settsDict["disabled"] = "true"
+        self.updateConf("imap", self.callerArgs.id, settsDict)
+
+
+    # -----------------------------------
+    # edits a config item from imap.conf
+    # -----------------------------------
+    def handleEdit(self, confInfo):
+
+        # let's make sure this thing exists, first...
+        existing = admin.ConfigInfo()
+        self.handleList(existing)
+        if not self.callerArgs.id in existing:
+            raise admin.ArgValidationException("Cannot edit '%s', it does not exist." % self.callerArgs.id)
+
+        self.updateConf("imap", self.callerArgs.id, self.callerArgs.data)
 
 
 admin.init(IMAPHandler, admin.ACTION_CREATE | admin.ACTION_EDIT | admin.ACTION_LIST | admin.ACTION_REMOVE)

--- a/bin/imap_python_handler.py
+++ b/bin/imap_python_handler.py
@@ -59,7 +59,7 @@ class IMAPHandler(admin.MConfigHandler):
         if not passwdProvided:
             raise admin.ArgValidationException("Either password or xpassword must be provided")
 
-        self.updateConf("imap", self.callerArgs.id, self.callerArgs.data);
+        self.updateConf("imap", self.callerArgs.id, self.callerArgs.data)
 
 
     # ---------------------------------------

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+[[ -d "dist" ]] || mkdir dist
+
+# Todo:  Refactor this so that the app and TA aren't stored in git twice (super painful version control); since most files are unchanged between the 2 use cases
+ksconf package . \
+    -f "dist/IMAPmailbox-{{version}}.tar.gz" \
+    --app-name "IMAPmailbox" \
+    --block-local \
+    -b '.bumpversion.cfg' \
+    -b '.gitignore' \
+    -b '.pre-commit-config.yaml' \
+    -b 'dist' \
+    -b 'build.sh' \
+    --hook-script "cp bin/get_imap_email.py appserver/addons/IMAPmailbox-TA/bin/"

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
+#
+# For a lazy, yet effective tight developer loop:
+#
+#   ./build.sh && $SPLUNK_HOME/bin/splunk install app $(<.release) -update 1
+
+set -e
+
 [[ -d "dist" ]] || mkdir dist
+
 
 # Todo:  Refactor this so that the app and TA aren't stored in git twice (super painful version control); since most files are unchanged between the 2 use cases
 ksconf package . \
@@ -11,4 +19,5 @@ ksconf package . \
     -b '.pre-commit-config.yaml' \
     -b 'dist' \
     -b 'build.sh' \
+    --release-file .release \
     --hook-script "cp bin/get_imap_email.py appserver/addons/IMAPmailbox-TA/bin/"

--- a/default/app.conf
+++ b/default/app.conf
@@ -1,20 +1,21 @@
 # splunk app configuration file
-[package]
-id = IMAPmailbox
-check_for_updates = 1
+
+[install]
+build = 7
+state = enabled
 
 [launcher]
 author = pbalsley
 description = Index email from an IMAP mailbox.
-version = 2.0.5
+version = 2.0.4
+
+[package]
+check_for_updates = 1
+id = IMAPmailbox
+
+[triggers]
+reload.imap = simple
 
 [ui]
 is_visible = true
 label = IMAP Mailbox
-
-[install]
-state = enabled
-build = 7
-
-[triggers]
-reload.imap = simple

--- a/default/app.conf
+++ b/default/app.conf
@@ -6,7 +6,7 @@ check_for_updates = 1
 [launcher]
 author = pbalsley
 description = Index email from an IMAP mailbox.
-version = 2.0.4
+version = 2.0.5
 
 [ui]
 is_visible = true
@@ -14,8 +14,7 @@ label = IMAP Mailbox
 
 [install]
 state = enabled
-build = 6
-install_source_checksum = e023818848d0aaa462fc217a84200c91f78baa6d
+build = 7
 
 [triggers]
 reload.imap = simple

--- a/default/app.conf
+++ b/default/app.conf
@@ -7,7 +7,7 @@ state = enabled
 [launcher]
 author = pbalsley
 description = Index email from an IMAP mailbox.
-version = 2.0.4
+version = 2.0.5
 
 [package]
 check_for_updates = 1

--- a/default/imap.conf
+++ b/default/imap.conf
@@ -1,3 +1,4 @@
+# KSCONF-NO-SORT
 #
 # IMAP app
 # IMAP connection and indexing configuration
@@ -15,7 +16,7 @@
 #
 # server
 #
-# The host name or IP address of the IMAP server that will provide the 
+# The host name or IP address of the IMAP server that will provide the
 # mail to be indexed.
 #
 server = YOUR_SERVER_HERE
@@ -32,8 +33,8 @@ user = YOUR_USER_NAME_HERE
 #
 # User's password for the IMAP server in encrypted text.
 #
-# To get an encrypted version of you password, run the bin/genpass.sh script 
-# Copy and paste its encrypted password output as the value here. 
+# To get an encrypted version of you password, run the bin/genpass.sh script
+# Copy and paste its encrypted password output as the value here.
 #
 xpassword =
 
@@ -42,11 +43,11 @@ xpassword =
 #
 # User's password for the IMAP server in plaintext.
 #
-# WARNING: placing plaintext passwords in a configuration file is a significant 
+# WARNING: placing plaintext passwords in a configuration file is a significant
 # security risk.  It is recommended that you leave this setting blank and
 # instead use the xpassword setting above.
 #
-password = 
+password =
 
 
 # ===================================
@@ -80,10 +81,10 @@ fullHeaders = False
 #
 # includeBody
 #
-# If True, each message body will be indexed.  In the case of multipart 
+# If True, each message body will be indexed.  In the case of multipart
 # messages, indexing will occur on all parts whose content type is in the
 # mimeTypes list (see below).  If you don't need to search message bodies
-# in Splunk, setting this to False can reduce database size and increase 
+# in Splunk, setting this to False can reduce database size and increase
 # performance.
 #
 includeBody = True
@@ -91,7 +92,7 @@ includeBody = True
 #
 # mimeTypes
 #
-# Comma-separated list mime types to be indexed.(no spaces!)  When a multipart 
+# Comma-separated list mime types to be indexed.(no spaces!)  When a multipart
 # message is encountered, only parts of a type found in this list
 # will be indexed.
 #
@@ -103,17 +104,17 @@ mimeTypes = text/plain
 #
 # folders
 #
-# A comma-separated list of folders to be indexed, e.g. 
+# A comma-separated list of folders to be indexed, e.g.
 #
 #   INBOX.bugs, INBOX.support, INBOX.checkins
 #
-# If you wish to index everything, set this value to "all".   If folder is 
-# blank, then the default (typically 'INBOX') will be used.  
+# If you wish to index everything, set this value to "all".   If folder is
+# blank, then the default (typically 'INBOX') will be used.
 #
 folders = all
 
 #
-# imapSearch 
+# imapSearch
 #
 # Provides an IMAP4 search expression that is used to query
 # for messages to be retrieved from the IMAP server for indexing.
@@ -122,20 +123,20 @@ folders = all
 # which are smaller than 200k.  You can modify this value to further
 # narrow the set of messages that will be retrieved.
 #
-# For example, the following imapSearch will retrieve all undeleted 
-# messages smaller than 200k that were sent by erik@splunk.com since 
+# For example, the following imapSearch will retrieve all undeleted
+# messages smaller than 200k that were sent by erik@splunk.com since
 # Feburary 1997:
 #
 #   UNDELETED SMALLER 204800 FROM "erik@splunk.com" SINCE 1-Feb-1997
 #
-# As another example, the following imapSearch will retrieve 
+# As another example, the following imapSearch will retrieve
 # all undeleted messages with the word 'chocolate' in the body and the word
 # 'cake' or 'ice cream' in the subject:
 #
 #   UNDELETED BODY "chocolate" (OR SUBJECT "cake" SUBJECT "ice cream")
 #
 #
-# A complete description of search strings can be found in section 6.4.4 
+# A complete description of search strings can be found in section 6.4.4
 # of the IMAP specification:
 #
 #   http://www.isi.edu/in-notes/rfc3501.txt
@@ -146,14 +147,14 @@ imapSearch = UNDELETED
 # deleteWhenDone
 #
 # If true will delete messages from mailbox after indexing.
-# Should note that deteleWhenDone overrides any caching and assumes that each time 
+# Should note that deteleWhenDone overrides any caching and assumes that each time
 # the script gets called all messages in the inbox are new.
 #
 # I have noticed if you do not delete mail. Checking for mail can get extremely slow.
 #
 deleteWhenDone = True
 
-# 
+#
 # debug
 #
 # If true, extra processing info will be output (and indexed).  You
@@ -164,12 +165,12 @@ debug = False
 #
 # noCache
 #
-# If true, the 'read message' cache will be ignored.  This effectively causes 
-# all matching messages to be retrieved and indexed repeatedly; you probably 
+# If true, the 'read message' cache will be ignored.  This effectively causes
+# all matching messages to be retrieved and indexed repeatedly; you probably
 # don't want to set this to True.
 #
 #
-noCache = False 
+noCache = False
 
 #If caching is turned on, we need to retrieve the latest UID from the splunk servers
 #This is the userid for a default splunk installation. Change it to whatever user account
@@ -183,7 +184,7 @@ splunkpassword = changeme
 
 #This is the encrypted password for the splunk installation. Change it appropriately if you have set
 #it up differently.
-splunkxpassword = 
+splunkxpassword =
 
 #Path to the splunk host path. If yours is different from the default change this to
 #https://<hostname>:<port>

--- a/default/inputs.conf
+++ b/default/inputs.conf
@@ -1,22 +1,22 @@
 # Below we define to script stanza exactly the same but with different path seperators.
 # This allows us to work on either windows or *nix.
-# Enable the input you need based on your OS: 
-#   on = "disabled = false" 
+# Enable the input you need based on your OS:
+#   on = "disabled = false"
 #  off = "disabled = true"
 # Default email check is 5 minutes, or 300 seconds. Adjust as you wish.
 
-# *nix systems
 [script://./bin/get_imap_email.py]
-interval = 300
-sourcetype = imap
-source = imap
+# *nix systems
+disabled = false
 index = mail
-disabled = false 
+interval = 300
+source = imap
+sourcetype = imap
 
-# windows
 [script://.\bin\get_imap_email.py]
-interval = 300
-sourcetype = imap
-source = imap
+# windows
+disabled = true
 index = mail
-disabled = true 
+interval = 300
+source = imap
+sourcetype = imap

--- a/metadata/default.meta
+++ b/metadata/default.meta
@@ -2,133 +2,128 @@
 access = read : [ * ], write : [ admin, power ]
 export = none
 
-[tags]
+[app/launcher]
+modtime = 1393630549.940260000
+version = 6.0.1
+
+[app/ui]
+modtime = 1393630549.937647000
+version = 6.0.1
+
+[datamodels/Email_Headers]
+access = read : [ * ], write : [ admin ]
+export = none
+modtime = 1393891876.186549000
+owner = nobody
+version = 6.0.1
+
+[lookups]
 export = system
 
+[models/Email_Headers]
+access = read : [ * ], write : [ admin ]
+export = none
+modtime = 1393891876.198047000
+owner = nobody
+version = 6.0.1
+
+[nav/default]
+modtime = 1393641834.275618000
+version = 6.0.1
+
 [props]
+export = system
+
+[savedsearches/IMAP%20-%20Count%20of%20messages%20by%20hour]
+access = read : [ * ], write : [ admin, power ]
+export = none
+modtime = 1395766872.461492000
+owner = nobody
+version = 6.0.1
+
+[savedsearches/IMAP%20-%20Count%20of%20messages%20by%20month%2Fyear]
+access = read : [ * ], write : [ admin, power ]
+export = none
+modtime = 1395767775.780770000
+owner = nobody
+version = 6.0.1
+
+[savedsearches/IMAP%20-%20Count%20of%20messages%20this%20month]
+access = read : [ * ], write : [ admin, power ]
+export = none
+modtime = 1395769073.873281000
+owner = nobody
+version = 6.0.1
+
+[savedsearches/IMAP%20-%20Cron%20Warnings]
+access = read : [ * ], write : [ admin, power ]
+export = none
+modtime = 1395768006.220105000
+owner = nobody
+version = 6.0.1
+
+[savedsearches/IMAP%20-%20Messages%20with%20Delivery%20problems]
+access = read : [ * ], write : [ admin, power ]
+export = none
+modtime = 1395768303.338575000
+owner = nobody
+version = 6.0.1
+
+[savedsearches/IMAP%20-%20Top%20From%20Addresses]
+access = read : [ * ], write : [ admin, power ]
+export = none
+modtime = 1395768631.789833000
+owner = nobody
+version = 6.0.1
+
+[savedsearches/IMAP%20-%20Top%20Subjects]
+access = read : [ * ], write : [ admin, power ]
+export = none
+modtime = 1395768714.341926000
+owner = nobody
+version = 6.0.1
+
+[savedsearches/IMAP%20-%20Top%20To%20Addresses]
+access = read : [ * ], write : [ admin, power ]
+export = none
+modtime = 1395769136.378325000
+owner = nobody
+version = 6.0.1
+
+[savedsearches/IMAP%20-%20get_imap_email.py%20errors]
+access = read : [ admin ], write : [ admin ]
+export = none
+modtime = 1395768108.195652000
+owner = nobody
+version = 6.0.1
+
+[tags]
 export = system
 
 [transforms]
 export = system
 
-[lookups]
-export = system
-
-[viewstates]
-access = read : [ * ], write : [ * ]
-export = system
-
-[app/ui]
-version = 6.0.1
-modtime = 1393630549.937647000
-
-[app/launcher]
-version = 6.0.1
-modtime = 1393630549.940260000
-
-[nav/default]
-version = 6.0.1
-modtime = 1393641834.275618000
-
 [views/mail_summary]
 access = read : [ * ]
 export = none
+modtime = 1395785238.668236000
 owner = nobody
 version = 6.0.1
-modtime = 1395785238.668236000
 
 [views/top_message_data]
 access = read : [ * ], write : [ admin ]
 export = none
+modtime = 1395772016.990039000
 owner = nobody
 version = 6.0.1
-modtime = 1395772016.990039000
 
 [views/user_search]
 access = read : [ * ], write : [ admin ]
 export = none
-owner = nobody
-version = 6.0.1
 modtime = 1393643982.486548000
-
-[datamodels/Email_Headers]
-access = read : [ * ], write : [ admin ]
-export = none
 owner = nobody
 version = 6.0.1
-modtime = 1393891876.186549000
 
-[models/Email_Headers]
-access = read : [ * ], write : [ admin ]
-export = none
-owner = nobody
-version = 6.0.1
-modtime = 1393891876.198047000
-
-[app/install/state]
-version = 6.0.1
-modtime = 1394176963.856280000
-
-[savedsearches/IMAP%20-%20Count%20of%20messages%20by%20hour]
-access = read : [ * ], write : [ admin, power ]
-export = none
-owner = nobody
-version = 6.0.1
-modtime = 1395766872.461492000
-
-[savedsearches/IMAP%20-%20Count%20of%20messages%20by%20month%2Fyear]
-access = read : [ * ], write : [ admin, power ]
-export = none
-owner = nobody
-version = 6.0.1
-modtime = 1395767775.780770000
-
-[savedsearches/IMAP%20-%20Cron%20Warnings]
-access = read : [ * ], write : [ admin, power ]
-export = none
-owner = nobody
-version = 6.0.1
-modtime = 1395768006.220105000
-
-[savedsearches/IMAP%20-%20get_imap_email.py%20errors]
-access = read : [ admin ], write : [ admin ]
-export = none
-owner = nobody
-version = 6.0.1
-modtime = 1395768108.195652000
-
-[savedsearches/IMAP%20-%20Messages%20with%20Delivery%20problems]
-access = read : [ * ], write : [ admin, power ]
-export = none
-owner = nobody
-version = 6.0.1
-modtime = 1395768303.338575000
-
-[savedsearches/IMAP%20-%20Top%20From%20Addresses]
-access = read : [ * ], write : [ admin, power ]
-export = none
-owner = nobody
-version = 6.0.1
-modtime = 1395768631.789833000
-
-[savedsearches/IMAP%20-%20Top%20To%20Addresses]
-access = read : [ * ], write : [ admin, power ]
-export = none
-owner = nobody
-version = 6.0.1
-modtime = 1395769136.378325000
-
-[savedsearches/IMAP%20-%20Top%20Subjects]
-access = read : [ * ], write : [ admin, power ]
-export = none
-owner = nobody
-version = 6.0.1
-modtime = 1395768714.341926000
-
-[savedsearches/IMAP%20-%20Count%20of%20messages%20this%20month]
-access = read : [ * ], write : [ admin, power ]
-export = none
-owner = nobody 
-version = 6.0.1
-modtime = 1395769073.873281000
-
+[viewstates]
+access = read : [ * ], write : [ * ]
+export = system


### PR DESCRIPTION
This is my incomplete attempt to add Python 3 (and therefore Splunk 8) support into this add on.  I ultimately got frustrated with this code base (scripted input vs modular input, secret management, lack of multi account support, ...) and ended up switching to [TA-mailclient](https://splunkbase.splunk.com/app/3200/) and completing Python 3 support for it (https://github.com/seunomosowon/TA-mailclient/pull/13).  But I think I was getting fairly close, so I'll leave my work here in case it helps anyone else get this over the finish line.  


Note that because there's been no activity here for years, I figured I may have to step and take over, or at least make a one-off (unofficial) release or two so I added in some of my typical tools and best practices to make the process easier.  This should be pretty cleanly separated out in commits in case you'd like to abandon those bits.


## Things done:

* Existing PRs merged.  Specifically #5 and #6
* Replaced many python2isms with Python 2/3 compatible syntax.
* No more mixed whitespaces.  All tabs have been obliterated, in accordance with the Python way. 
* I added simple build script, code checking (pre-commit), and version incrementing helper tool (bump2version).  The build process relies on [ksconf](https://github.com/Kintyre/ksconf) for the actual package creation.
* See individual commit messages for more detail.

## Things not done:

* Test it under real conditions
* Encoding and possibly standard library mail client issues?  This is highly likely.
* 2 apps in 1!  I didn't realize until late in the game that there's actually 2 copies of the python script (because of the nested TA under `appserver/addons/IMAPmailbox-TA/`), so I haven't touched that one.  I was going to attempt to fix that with a smarter build script that referenced a single source of truth, but I didn't get there.

Best of luck.  I hope someone ultimately gets some value out of my afternoon of abandoned work.